### PR TITLE
sign p2sh produces invalid signatures (random K) 

### DIFF
--- a/examples/sign_p2sh_stepbystep.php
+++ b/examples/sign_p2sh_stepbystep.php
@@ -58,6 +58,7 @@ RawTransaction::private_keys_to_wallet($wallet, array("cV2BRcdtWoZMSovYCpoY9gyvj
 RawTransaction::redeem_scripts_to_wallet($wallet, array($redeem_script));
 $sign = RawTransaction::sign($wallet, $raw_transaction, json_encode($inputs));
 print_r($sign);
+var_dump(2 == $sign['req_sigs'], 1 == $sign['sign_count'], 'false' === $sign['complete']);
 
 /*
  * sign with second key
@@ -67,6 +68,7 @@ RawTransaction::private_keys_to_wallet($wallet, array("cMps8Dg4Z1ThcwvPiPpshR6cb
 RawTransaction::redeem_scripts_to_wallet($wallet, array($redeem_script));
 $sign = RawTransaction::sign($wallet, $sign['hex'], json_encode($inputs));
 print_r($sign);
+var_dump(2 == $sign['req_sigs'], 2 == $sign['sign_count'], 'true' === $sign['complete']);
 
 /*
  * sign with third key
@@ -76,4 +78,5 @@ RawTransaction::private_keys_to_wallet($wallet, array("cNn72iUvQhuzZCWg3TC31fvyN
 RawTransaction::redeem_scripts_to_wallet($wallet, array($redeem_script));
 $sign = RawTransaction::sign($wallet, $sign['hex'], json_encode($inputs));
 print_r($sign);
+var_dump(2 == $sign['req_sigs'], 3 == $sign['sign_count'], 'true' === $sign['complete']);
 

--- a/tests/RawTransactionTest.php
+++ b/tests/RawTransactionTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use BitWasp\BitcoinLib\BitcoinLib;
 use BitWasp\BitcoinLib\RawTransaction as RawTransaction;
 
 require_once(__DIR__. '/../vendor/autoload.php');
@@ -48,6 +49,74 @@ class RawTransactionTest extends PHPUnit_Framework_TestCase
             $raw = RawTransaction::decode_redeem_script($sample);
             $this->assertTrue( is_array($raw) );
         }
+    }
+
+    /**
+     * !! TESTNET !!
+     *
+     */
+    public function testSignP2SH() {
+        // this should be > 100 but it takes ~4 seconds per loop :/
+        for ($i = 0; $i < 10; $i++) {
+            $this->_testSignP2SH();
+        }
+    }
+
+    protected function _testSignP2SH() {
+        BitcoinLib::setMagicByteDefaults('bitcoin-testnet');
+
+        $redeem_script = "522103c0b1fd07752ebdd43c75c0a60d67958eeac8d4f5245884477eae094c4361418d2102ab1fae8dacd465460ad8e0c08cb9c25871782aa539a58b65f9bf1264c355d0982102dc43b58ee5313d1969b939718d2c8104a3365d45f12f91753bfc950d16d3e82e53ae";
+
+        $inputs = array(
+            array(
+                "txid" => "83c5c88e94d9c518f314e30ca0529ab3f8e5e4f14a8936db4a32070005e3b61f",
+                "vout" => 0,
+                "scriptPubKey" => "a9145fe34588f475c5251ff994eafb691a5ce197d18b87",
+
+                // only needed for RawTransaction::sign
+                "redeemScript" => $redeem_script,
+
+                // only for debugging
+                "value" => 0.00010000
+            )
+        );
+        $outputs = array(
+            "n3P94USXs7LzfF4BKJVyGv2uCfBQRbvMZJ" => 0.00010000
+        );
+        $raw_transaction = RawTransaction::create($inputs, $outputs);
+
+        /*
+         * sign with first key
+         */
+        $wallet = array();
+        RawTransaction::private_keys_to_wallet($wallet, array("cV2BRcdtWoZMSovYCpoY9gyvjiVK5xufpAwdAFk1jdonhGZq1cCm"));
+        RawTransaction::redeem_scripts_to_wallet($wallet, array($redeem_script));
+        $sign = RawTransaction::sign($wallet, $raw_transaction, json_encode($inputs));
+        $this->assertEquals(2, $sign['req_sigs']);
+        $this->assertEquals(1, $sign['sign_count']);
+        $this->assertEquals('false', $sign['complete']);
+
+        /*
+         * sign with second key
+         */
+        $wallet = array();
+        RawTransaction::private_keys_to_wallet($wallet, array("cMps8Dg4Z1ThcwvPiPpshR6cbosYoTrgUwgLcFasBSxsdLHwzoUK"));
+        RawTransaction::redeem_scripts_to_wallet($wallet, array($redeem_script));
+        $sign = RawTransaction::sign($wallet, $sign['hex'], json_encode($inputs));
+        $this->assertEquals(2, $sign['req_sigs']);
+        $this->assertEquals(2, $sign['sign_count']);
+        $this->assertEquals('true', $sign['complete']);
+
+        /*
+         * sign with third key
+         */
+        $wallet = array();
+        RawTransaction::private_keys_to_wallet($wallet, array("cNn72iUvQhuzZCWg3TC31fvyNDYttL8emHgMcFJzhF4xnFo8LYCk"));
+        RawTransaction::redeem_scripts_to_wallet($wallet, array($redeem_script));
+        $sign = RawTransaction::sign($wallet, $sign['hex'], json_encode($inputs));
+        $this->assertEquals(2, $sign['req_sigs']);
+        $this->assertEquals(3, $sign['sign_count']);
+        $this->assertEquals('true', $sign['complete']);
     }
 
     public function testCreateRaw() {


### PR DESCRIPTION
## DONT MERGE THIS

this PR isn't a proper fix, but I figured it was the easiest way to share some code to show the problem.  
_disclaimer;_ I'm not a crypto-god, so I can't explain why it doesn't work and neither why I can fix it, I'm hoping one of you guys can :D

I was testing signing a p2sh in 2 steps, first signing once with the 1st PK and then signing again with the 2nd PK and I ran into an inconsistency.  
When signing with the 2nd PK it randomly fails to detect the previous signature, as in the `sign_count` would be 0.

When digging in deeper I figured it was because of the random bytes used as the `random_k` for `PrivateKey::sign`, digging a little deeper I figured out that the signature produced wasn't valid all the time if I would run it through `is_canonical_signature`.  
My current 'fix' is wrapping it in a `do {} while();` until it produces a valid signature, where 10 tries weren't enough so I changed the max tries to 100 ... but it's random so 100 isn't very safe either!

I hope you guys understand this problem better than I do, all that I can figure out is that bitcore explicitly doesn't support the 'determenistic K' when signing (https://github.com/bitpay/bitcore/blob/master/lib/Key.js#L14)...

I doubt looping until it validates is the best aproach, but I see the same in bitcore being done -.-'  
It's also not the fastest process to loop ... it can easily take 4 seconds ...

The `php examples/sign_p2sh_stepbystep.php` script demostrates/tests the case, if you change the `RawTransactions::SIGN_TRIES` to 1 or anything below 10 you'll regularly see the test case failing.
