### PR TITLE
support BIP32 absolute path in BIP32::build_key

### DIFF
--- a/src/BIP32.php
+++ b/src/BIP32.php
@@ -289,7 +289,7 @@ class BIP32
         if (strtolower(substr($string_def, 0, 1)) == 'm') {
             // the desired definition should start with the definition
             if (strpos($string_def, $def) !== 0) {
-                throw new \Exception("!!");
+                throw new \Exception("Path ({$string_def}) should match parent path ({$def}) when building key by absolute path");
             }
 
             // unshift the definition to make the desired definition relative

--- a/tests/BIP32Test.php
+++ b/tests/BIP32Test.php
@@ -61,6 +61,14 @@ class BIP32Test extends PHPUnit_Framework_TestCase
         $bip44ChildKey = $this->bip32->build_key($bip44ChildKey, "0'/0/0");
         $this->assertEquals("m/44'/0'/0'/0/0", $bip44ChildKey[1]);
         $this->assertEquals("xprvA4A9CuBXhdBtCaLxwrw64Jaran4n1rgzeS5mjH47Ds8V67uZS8tTkG8jV3BZi83QqYXPcN4v8EjK2Aof4YcEeqLt688mV57gF4j6QZWdP9U", $bip44ChildKey[0]);
+
+        try {
+            $bip44ChildKey = $this->bip32->build_key($masterKey, "m/44'/0'/0'/0/0");
+            $this->bip32->build_key($bip44ChildKey, "m/44'/1'/0'/0/0");
+            $this->fail("build_key should throw exception with bad path");
+        } catch (\Exception $e) {
+            $this->assertTrue(!!$e);
+        }
     }
 
     public function testMasterKeyFromSeed() {


### PR DESCRIPTION
This might need some review since there were barely any tests for creating new derivations, so I don't really know how it has been used so far ...

I just feel that being able to specify the absolute path is more sane, specially since currently if you do `BIP32::build_key($key, "m")` you get "m/0" because "m" is unpacked as "0" ...
