### PR TITLE
changed BitcoinLib::validate_address to also validate p2sh addresses.

### DIFF
--- a/src/BitcoinLib.php
+++ b/src/BitcoinLib.php
@@ -728,11 +728,15 @@ class BitcoinLib
      * address, otherwise returns TRUE;
      *
      * @param    string $address
-     * @param    string $address_version
+     * @param    string $magic_byte
+     * @param    string $magic_p2sh_byte
      * @return    boolean
      */
-    public static function validate_address($address, $address_version = null)
+    public static function validate_address($address, $magic_byte = null, $magic_p2sh_byte = null)
     {
+        $magic_byte = $magic_byte !== false ? self::magicByte($magic_byte) : false;
+        $magic_p2sh_byte = $magic_p2sh_byte !== false ? self::magicP2SHByte($magic_p2sh_byte) : false;
+
         // Check the address is decoded correctly.
         $decode = self::base58_decode($address);
         if (strlen($decode) !== 50) {
@@ -741,13 +745,12 @@ class BitcoinLib
 
         // Compare the version.
         $version = substr($decode, 0, 2);
-        if (hexdec($version) > hexdec(self::magicByte($address_version))) {
+        if ($version !== $magic_byte && $version !== $magic_p2sh_byte) {
             return false;
         }
 
         // Finally compare the checksums.
         return substr($decode, -8) == substr(self::hash256(substr($decode, 0, 42)), 0, 8);
-
     }
 
     /**

--- a/src/RawTransaction.php
+++ b/src/RawTransaction.php
@@ -1006,9 +1006,7 @@ class RawTransaction
         // Outputs is the set of [address/amount]
         $tx_array['vout'] = array();
         foreach ($outputs as $address => $value) {
-            if (BitcoinLib::validate_address($address, $magic_byte) == false
-                && BitcoinLib::validate_address($address, $magic_p2sh_byte) == false
-            ) {
+            if (!BitcoinLib::validate_address($address, $magic_byte, $magic_p2sh_byte)) {
                 return false;
             }
 

--- a/tests/AgainstRPCTest.php
+++ b/tests/AgainstRPCTest.php
@@ -11,6 +11,7 @@ class testAgainstRPC extends PHPUnit_Framework_TestCase {
 
     public function __construct() {
         $this->magic_byte = '00';
+        $this->magic_p2sh_byte = '05';
         $this->c = array('url' => 'http://bitcoinrpc:6Wk1SYL7JmPYoUeWjYRSdqij4xrM5rGBvC4kbJipLVJK@127.0.0.1:8332');
         $this->client = new Jsonrpcclient($this->c);
         if($this->client->getinfo() == null)
@@ -36,7 +37,7 @@ class testAgainstRPC extends PHPUnit_Framework_TestCase {
 
             // Ensure that the Bitcoind believes the address is valid, and that this matches what we think
             $this->assertTrue($validate['isvalid']);
-            $this->assertEquals($validate['isvalid'], $this->bitcoin->validate_address($set['pubAdd'],$this->magic_byte));
+            $this->assertEquals($validate['isvalid'], $this->bitcoin->validate_address($set['pubAdd'], $this->magic_byte, $this->magic_p2sh_byte));
 
         }
     }

--- a/tests/BitcoinLibTest.php
+++ b/tests/BitcoinLibTest.php
@@ -17,6 +17,7 @@ class BitcoinLibTest extends PHPUnit_Framework_TestCase
 	
 	public function __construct() {
         $this->addressVersion = '00';
+        $this->p2shAddressVersion = '05';
         $this->WIFVersion = '80';
         $this->keyConversionData = array(
             "5HxWvvfubhXpYYpS3tJkw6fq9jE9j18THftkZjHHfmFiWtmAbrj" => "1QFqqMUD55ZV3PJEJZtaKCsQmjLT6JkjvJ",
@@ -157,8 +158,8 @@ class BitcoinLibTest extends PHPUnit_Framework_TestCase
 	
 	///////////////////////////////////////////////////////
 	// base58_check testing
-	public function testBase58CheckEncode()
-	{
+    public function testBase58CheckEncode()
+    {
         for ($i = 0; $i < 500; $i++)
         {
             $this->setup();
@@ -170,10 +171,14 @@ class BitcoinLibTest extends PHPUnit_Framework_TestCase
             $decode = $this->bitcoin->base58_decode_checksum($encode);
 
             // validate 'manually' created address
-            $this->assertTrue($this->bitcoin->validate_address($encode, $this->addressVersion));
+            $this->assertTrue($this->bitcoin->validate_address($encode, $this->addressVersion, $this->p2shAddressVersion));
             // validate 'manually' created address without specifying the address version
             //  relying on the defaults
             $this->assertTrue($this->bitcoin->validate_address($encode));
+            // validate 'manually' created address
+            //  disable address version and P2S address version specifically
+            $this->assertFalse($this->bitcoin->validate_address($encode, false, null));
+            $this->assertTrue($this->bitcoin->validate_address($encode, null, false));
 
             // validate 'manually'
             $this->assertTrue($hex == $decode);
@@ -182,10 +187,14 @@ class BitcoinLibTest extends PHPUnit_Framework_TestCase
             $check2 = $this->bitcoin->hash160_to_address($hex, $this->addressVersion);
 
             // validate created address
-            $this->assertTrue($this->bitcoin->validate_address($check2, $this->addressVersion));
+            $this->assertTrue($this->bitcoin->validate_address($check2, $this->addressVersion, $this->p2shAddressVersion));
             // validate created address without specifying the address version
             //  relying on the defaults
             $this->assertTrue($this->bitcoin->validate_address($check2));
+            // validate created address
+            //  disable address version and P2S address version specifically
+            $this->assertFalse($this->bitcoin->validate_address($check2, false, null));
+            $this->assertTrue($this->bitcoin->validate_address($check2, null, false));
 
             // validate 'manually'
             $this->assertTrue($check2 == $encode);
@@ -195,17 +204,82 @@ class BitcoinLibTest extends PHPUnit_Framework_TestCase
             $check3 = $this->bitcoin->hash160_to_address($hex);
 
             // validate created address
-            $this->assertTrue($this->bitcoin->validate_address($check3, $this->addressVersion));
+            $this->assertTrue($this->bitcoin->validate_address($check3, $this->addressVersion, $this->p2shAddressVersion));
             // validate created address without specifying the address version
             //  relying on the defaults
             $this->assertTrue($this->bitcoin->validate_address($check3));
+            // validate created address
+            //  disable address version and P2S address version specifically
+            $this->assertFalse($this->bitcoin->validate_address($check3, false, null));
+            $this->assertTrue($this->bitcoin->validate_address($check3, null, false));
 
             // validate 'manually'
             $this->assertTrue($check3 == $encode);
 
             $this->tearDown();
         }
-	}
+    }
+    public function testBase58CheckEncodeP2SH()
+    {
+        for ($i = 0; $i < 500; $i++)
+        {
+            $this->setup();
+            // random, 20-byte string.
+            $hex = (string)bin2hex(openssl_random_pseudo_bytes(20));
+
+            // 'manually' create address
+            $encode = $this->bitcoin->base58_encode_checksum($this->p2shAddressVersion.$hex);
+            $decode = $this->bitcoin->base58_decode_checksum($encode);
+
+            // validate 'manually' created address
+            $this->assertTrue($this->bitcoin->validate_address($encode, $this->addressVersion, $this->p2shAddressVersion));
+            // validate 'manually' created address without specifying the address version
+            //  relying on the defaults
+            $this->assertTrue($this->bitcoin->validate_address($encode));
+            // validate 'manually' created address
+            //  disable address version and P2S address version specifically
+            $this->assertTrue($this->bitcoin->validate_address($encode, false, null));
+            $this->assertFalse($this->bitcoin->validate_address($encode, null, false));
+
+            // validate 'manually'
+            $this->assertTrue($hex == $decode);
+
+            // create address
+            $check2 = $this->bitcoin->hash160_to_address($hex, $this->p2shAddressVersion);
+
+            // validate created address
+            $this->assertTrue($this->bitcoin->validate_address($check2, $this->addressVersion, $this->p2shAddressVersion));
+            // validate created address without specifying the address version
+            //  relying on the defaults
+            $this->assertTrue($this->bitcoin->validate_address($check2));
+            // validate created address
+            //  disable address version and P2S address version specifically
+            $this->assertTrue($this->bitcoin->validate_address($check2, false, null));
+            $this->assertFalse($this->bitcoin->validate_address($check2, null, false));
+
+            // validate 'manually'
+            $this->assertTrue($check2 == $encode);
+
+            // create address,  without specifying the address version
+            //  relying on the defaults
+            $check3 = $this->bitcoin->hash160_to_address($hex, 'p2sh');
+
+            // validate created address
+            $this->assertTrue($this->bitcoin->validate_address($check3, $this->addressVersion, $this->p2shAddressVersion));
+            // validate created address without specifying the address version
+            //  relying on the defaults
+            $this->assertTrue($this->bitcoin->validate_address($check3));
+            // validate created address
+            //  disable address version and P2S address version specifically
+            $this->assertTrue($this->bitcoin->validate_address($check3, false, null));
+            $this->assertFalse($this->bitcoin->validate_address($check3, null, false));
+
+            // validate 'manually'
+            $this->assertTrue($check3 == $encode);
+
+            $this->tearDown();
+        }
+    }
 
     public function testKeyConversion() {
         $tests = $this->keyConversionData;

--- a/tests/RawTransactionTest.php
+++ b/tests/RawTransactionTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use BitWasp\BitcoinLib\BitcoinLib;
 use BitWasp\BitcoinLib\RawTransaction as RawTransaction;
 
 require_once(__DIR__. '/../vendor/autoload.php');
@@ -197,6 +198,25 @@ class RawTransactionTest extends PHPUnit_Framework_TestCase
         foreach($data as $test) {
             $this->assertTrue(RawTransaction::validate_signed_transaction($test['tx'], json_encode($test['inputs']),'00'));
         }
+    }
+
+
+    public function testP2SHMultisig() {
+        $n = 3;
+        $m = 2;
+
+        $k = [];
+        $pk_list = [];
+
+        for($i = 0; $i < $n; $i++){
+            $k[$i] = BitcoinLib::get_new_key_set();
+            $pk_list[] = $k[$i]['pubKey'];
+        }
+
+        $multisig = RawTransaction::create_multisig($m, $pk_list);
+
+        $this->assertTrue(!!$multisig['address']);
+        $this->assertTrue(BitcoinLib::validate_address($multisig['address']));
     }
 
 


### PR DESCRIPTION
it's still possible to set FALSE for one of the address version arguments if you'd for w/e reason want to verify only against one of them.
