### PR TITLE
hash_pbkdf2() compatibility for PHP versions 5.3 and 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "mdanter/ecc": "0.2.0",
-        "php": ">=5.3.3",
+        "php": ">=5.5.0",
         "ext-gmp": "*",
         "ext-mcrypt": "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     },
     "require": {
         "mdanter/ecc": "0.2.0",
-        "php": ">=5.5.0",
+        "php": ">=5.3.3",
+        "rych/hash_pbkdf2-compat": "~1.0",
         "ext-gmp": "*",
         "ext-mcrypt": "*"
     },


### PR DESCRIPTION
hash_pbkdf2() used in BIP39.php is only available from PHP 5.5 onwards