### PR TITLE
no longer using complex sorting logic for multisig

### DIFF
--- a/src/RawTransaction.php
+++ b/src/RawTransaction.php
@@ -907,8 +907,7 @@ class RawTransaction
     /**
      * Sort Multisig Keys
      *
-     * Accepts an array of public keys for multisig, and returns them sorted
-     * by length and by lexicographic order.
+     * Accepts an array of public keys for multisig, and returns them sorted by lexicographic order.
      *
      * @param    array $public_keys
      * @return    array
@@ -916,26 +915,9 @@ class RawTransaction
     public static function sort_multisig_keys($public_keys)
     {
         $sorted_keys = $public_keys;
-        usort($sorted_keys, function ($a, $b) {
-            $len_a = strlen($a);
-            $len_b = strlen($b);
 
-            $length = $len_a > $len_b ? $len_a : $len_b;
-            for ($i = 0; $i < $length; $i++) {
-                if (!isset($a[$i])) {
-                    return -1;
-                } else if (!isset($b[$i])) {
-                    return 1;
-                } else if ((int)$a[$i] < (int)$b[$i]) {
-                    return -1;
-                } else if ((int)$a[$i] > (int)$b[$i]) {
-                    return 1;
-                } else {
-                    continue;
-                }
-            }
-            return 0;
-        });
+        sort($sorted_keys);
+
         return $sorted_keys;
     }
 

--- a/tests/BitcoinLibTestNetTest.php
+++ b/tests/BitcoinLibTestNetTest.php
@@ -27,8 +27,10 @@ class BitcoinLibTestNetTest extends BitcoinLibTest
     }
     
 	public function tearDown() {
-        $this->bitcoin->setMagicByteDefaults('bitcoin');
-        $this->bitcoin = null;
+        if ($this->bitcoin) {
+            $this->bitcoin->setMagicByteDefaults('bitcoin');
+            $this->bitcoin = null;
+        }
     }
 }
 

--- a/tests/BitcoinLibTestNetTest.php
+++ b/tests/BitcoinLibTestNetTest.php
@@ -27,6 +27,7 @@ class BitcoinLibTestNetTest extends BitcoinLibTest
     }
     
 	public function tearDown() {
+        $this->bitcoin->setMagicByteDefaults('bitcoin');
         $this->bitcoin = null;
     }
 }

--- a/tests/RawTransactionTest.php
+++ b/tests/RawTransactionTest.php
@@ -188,7 +188,7 @@ class RawTransactionTest extends PHPUnit_Framework_TestCase
             )
         );
 
-        $outputs = array('1PGa6cMAzzrBpTtfvQTzX5PmUxsDiFzKyW' => "0.00015");
+        $outputs = array('1PGa6cMAzzrBpTtfvQTzX5PmUxsDiFzKyW' => BitcoinLib::toSatoshi(0.00015));
 
         $json_inputs = json_encode(
             array(

--- a/tests/RawTransactionTest.php
+++ b/tests/RawTransactionTest.php
@@ -107,6 +107,8 @@ class RawTransactionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(2, $sign['req_sigs']);
         $this->assertEquals(3, $sign['sign_count']);
         $this->assertEquals('true', $sign['complete']);
+
+        BitcoinLib::setMagicByteDefaults('bitcoin');
     }
 
     public function testCreateRaw() {
@@ -387,8 +389,6 @@ class RawTransactionTest extends PHPUnit_Framework_TestCase
         }, $privKeys);
 
         $pubKeys = RawTransaction::sort_multisig_keys($pubKeys);
-
-        var_dump($pubKeys);
 
         $multisig = RawTransaction::create_multisig($m, $pubKeys);
 

--- a/tests/SignVerifyMessageTest.php
+++ b/tests/SignVerifyMessageTest.php
@@ -68,8 +68,8 @@ class SignVerifyMessageTest extends PHPUnit_Framework_TestCase
     public function testSignMessageTestnet()
     {
         BitcoinLib::setMagicByteDefaults('bitcoin-testnet');
-
         $this->assertTrue(BitcoinLib::verifyMessage("mkiPAxhzUMo8mAwW3q95q7aNuXt6HzbbUA", "IND22TSMS2uuWyIn2Be49ajaGwNmiQtiCXrozev00cPFXpACe8LQYU/t6xp8YXb5SIVAnqEn/DailZw+OM85TM0=", "mkiPAxhzUMo8mAwW3q95q7aNuXt6HzbbUA"));
+        BitcoinLib::setMagicByteDefaults('bitcoin');
     }
 
     public function testVerifyMessageDataSet()


### PR DESCRIPTION
@afk11 @btcdrak 

It's a bit of a gray area on how the pubkeys should be sorted, it's not specified in any BIP (it should be imo), some libraries don't do any sorting, some do ...

The old code was flawed, it was converting the characters to int one by one, so "024c" was converted to "0240" and would thus be before "0242" ...
And I can't find any other implementations that do sorting by length first, so it's a bit odd too ...

I sugest going back to plain old `sort()`, this breaks backwards compatability!  
Do we just bump the version number and go for it? or create a 2nd function for sorting and mark the current as deprecated?

bitcore does simple lexicographic sorting; 
https://github.com/bitpay/bitcore/blob/50a868cb8cdf2be04bb1c5bf4bcc064cc06f5888/lib/script/script.js#L541