### PR TITLE
add check for min and max length of BIP32 seed

### DIFF
--- a/examples/bip32.php
+++ b/examples/bip32.php
@@ -4,10 +4,7 @@ use BitWasp\BitcoinLib\BIP32;
 
 require_once(__DIR__. '/../vendor/autoload.php');
 
-$seed = bin2hex(mcrypt_create_iv(128, \MCRYPT_DEV_URANDOM));
-$master = BIP32::master_key($seed);
-
-
+$master = BIP32::master_key(bin2hex(mcrypt_create_iv(64, \MCRYPT_DEV_URANDOM)));
 
 // Load a 128 bit key, and convert this to extended key format.
 //$master = BIP32::master_key('41414141414141414141414141414141414141');

--- a/src/BIP32.php
+++ b/src/BIP32.php
@@ -77,12 +77,24 @@ class BIP32
      * @param    string       $seed
      * @param    string(opt)  $network
      * @param    boolean(opt) $testnet
+     * @param    boolean(opt) $ignoreLengthCheck        disable the length checks
      * @return    string
      */
-    public static function master_key($seed, $network = 'bitcoin', $testnet = false)
+    public static function master_key($seed, $network = 'bitcoin', $testnet = false, $ignoreLengthCheck = false)
     {
+        $seed = pack("H*", $seed);
+
+        // seed min length is 128 bits (16 bytes)
+        if (!$ignoreLengthCheck && strlen($seed) < 16) {
+            throw new \Exception("Seed should be at least 128 bits'");
+        }
+        // seed max length is 512 bits (64 bytes)
+        if (!$ignoreLengthCheck && strlen($seed) > 64) {
+            throw new \Exception("Seed should be at most 512 bits'");
+        }
+
         // Generate HMAC hash, and the key/chaincode.
-        $I = hash_hmac('sha512', pack("H*", $seed), "Bitcoin seed");
+        $I = hash_hmac('sha512', $seed, "Bitcoin seed");
         $I_l = substr($I, 0, 64);
         $I_r = substr($I, 64, 64);
 

--- a/tests/BIP39Test.php
+++ b/tests/BIP39Test.php
@@ -1,5 +1,6 @@
 <?php
 
+use BitWasp\BitcoinLib\BIP32;
 use BitWasp\BitcoinLib\BIP39\BIP39;
 
 require_once(__DIR__. '/../vendor/autoload.php');
@@ -231,6 +232,9 @@ class BIP39Test extends PHPUnit_Framework_TestCase {
             $entropy2 = BIP39::mnemonicToEntropy($mnemonic);
             $this->assertTrue(!!$entropy2);
             $this->assertEquals($entropy, $entropy2);
+
+            $bip32 = BIP32::master_key(BIP39::mnemonicToSeedHex($mnemonic, 'PASSWORD'));
+            $this->assertTrue(!!$bip32);
         }
 
         for ($i = 0; $i < 100; $i++) {
@@ -243,6 +247,9 @@ class BIP39Test extends PHPUnit_Framework_TestCase {
             $entropy2 = BIP39::mnemonicToEntropy($mnemonic);
             $this->assertTrue(!!$entropy2);
             $this->assertEquals($entropy, $entropy2);
+
+            $bip32 = BIP32::master_key(BIP39::mnemonicToSeedHex($mnemonic, 'PASSWORD'));
+            $this->assertTrue(!!$bip32);
         }
 
         for ($i = 0; $i < 100; $i++) {
@@ -255,6 +262,9 @@ class BIP39Test extends PHPUnit_Framework_TestCase {
             $entropy2 = BIP39::mnemonicToEntropy($mnemonic);
             $this->assertTrue(!!$entropy2);
             $this->assertEquals($entropy, $entropy2);
+
+            $bip32 = BIP32::master_key(BIP39::mnemonicToSeedHex($mnemonic, 'PASSWORD'));
+            $this->assertTrue(!!$bip32);
         }
     }
 }


### PR DESCRIPTION
BIP32 spec defines min/max length, implemented a check for it.

since there might be other suckers like me who excidently generated 512 bytes instead of 512 bits seeds there's an `$ignoreLengthCheck` option.