### PR TITLE
Bring phpecc version up to latest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     },
     "require": {
-        "mdanter/ecc": "0.2.0",
+        "mdanter/ecc": "dev-master#89640a0873e212a723212e7f374f973b7d1fe6f6",
         "php": ">=5.3.3",
         "rych/hash_pbkdf2-compat": "~1.0",
         "ext-gmp": "*",

--- a/src/BitcoinLib.php
+++ b/src/BitcoinLib.php
@@ -9,7 +9,8 @@ use Mdanter\Ecc\Point;
 use Mdanter\Ecc\PointInterface;
 use Mdanter\Ecc\PrivateKey;
 use Mdanter\Ecc\PublicKey;
-use Mdanter\Ecc\Signature;
+use Mdanter\Ecc\Signature\Signature;
+use Mdanter\Ecc\Signature\Signer;
 
 /**
  * BitcoinLib
@@ -673,7 +674,8 @@ class BitcoinLib
                 : (($math->mod($y0, 2) !== '0') ? $y0 : $y1);
 
             $y_coordinate = str_pad($math->decHex($y), 64, '0', STR_PAD_LEFT);
-            $point = new Point($curve, $x, $y, $generator->getOrder(), $math);
+            $point = $curve->getPoint($x, $y);
+
         } catch (\Exception $e) {
             return false;
         }
@@ -712,7 +714,7 @@ class BitcoinLib
             // Attempt to create the point. Point returns false in the
             // constructor if anything is invalid.
             try {
-                $point = new Point($generator->getCurve(), $x, $y, $generator->getOrder(), $math);
+                $point = $generator->getCurve()->getPoint($x, $y);
                 return true;
             } catch (\Exception $e) {
                 return false;
@@ -821,25 +823,22 @@ class BitcoinLib
 
         $messageHash = "\x18Bitcoin Signed Message:\n" . hex2bin(RawTransaction::_encode_vint(strlen($message))) . $message;
         $messageHash = hash('sha256', hash('sha256', $messageHash, true), true);
-
-        $pubKey = self::private_key_to_public_key($privateKey['key'], $privateKey['is_compressed']);
-
-        $uncompressedKey = self::decompress_public_key($pubKey);
-        $uncompressedKey = $uncompressedKey['public_key'];
-
-        $x = $math->hexDec(substr($uncompressedKey, 2, 64));
-        $y = $math->hexDec(substr($uncompressedKey, 66, 64));
+        $messageHash = $math->hexDec(bin2hex($messageHash));
         $key_dec = $math->hexDec($privateKey['key']);
 
-        $point = new Point($generator->getCurve(), $x, $y, $generator->getOrder(), $math);
-        $_publicKey = new PublicKey($generator, $point, $math);
-        $_privateKey = new PrivateKey($_publicKey, $key_dec, $math);
+        $pubKey = self::private_key_to_public_key($privateKey['key'], false);
+        $x = $math->hexDec(substr($pubKey, 2, 64));
+        $y = $math->hexDec(substr($pubKey, 66, 64));
+        $point = $generator->getCurve()->getPoint($x, $y);
 
-        $sign = $_privateKey->sign($math->hexDec((string)bin2hex($messageHash)), $k ?: $math->hexDec((string)bin2hex(mcrypt_create_iv(32, \MCRYPT_DEV_URANDOM))));
+        $_publicKey = new PublicKey($math, $generator, $point);
+        $_privateKey = $generator->getPrivateKeyFrom($key_dec);
+        $signer = new Signer($math);
+        $sign = $signer->sign($_privateKey, $messageHash, $k ?: $math->hexDec((string)bin2hex(mcrypt_create_iv(32, \MCRYPT_DEV_URANDOM))));
 
         // calculate the recovery param
         //  there should be a way to get this when signing too, but idk how ...
-        $i = self::calcPubKeyRecoveryParam($sign->getR(), $sign->getS(), $math->hexDec((string)bin2hex($messageHash)), $_publicKey->getPoint());
+        $i = self::calcPubKeyRecoveryParam($sign->getR(), $sign->getS(), $messageHash, $_publicKey->getPoint());
 
         return base64_encode(self::encodeMessageSignature($sign, $i, true));
     }
@@ -941,11 +940,11 @@ class BitcoinLib
             $y = $beta;
         }
 
-        // 1.4 Check that nR is at infinity (implicitly done in construtor)
-        $R = new Point($curve, $x, $y, $G->getOrder(), $math);
+        // 1.4 Check that nR is at infinity (implicitly done in constructor)
+        $R = $G->getCurve()->getPoint($x, $y);
 
-        $point_negate = function (PointInterface $p) use ($math) {
-            return new Point($p->getCurve(), $p->getX(), $math->mul($p->getY(), -1), $p->getOrder(), $math);
+        $point_negate = function (PointInterface $p) use ($math, $G) {
+            return $G->getCurve()->getPoint($p->getX(), $math->mul($p->getY(), -1));
         };
 
         // 1.6.1 Compute a candidate public key Q = r^-1 (sR - eG)
@@ -954,8 +953,9 @@ class BitcoinLib
         $Q = $R->mul($s)->add($eGNeg)->mul($rInv);
 
         // 1.6.2 Test Q as a public key
-        $Qk = new PublicKey($G, $Q, $math);
-        if ($Qk->verifies($e, $signature)) {
+        $signer = new Signer($math);
+        $Qk = new PublicKey($math, $G, $Q);
+        if ($signer->verify($Qk, $signature, $e)) {
             return $Qk;
         }
 

--- a/src/RawTransaction.php
+++ b/src/RawTransaction.php
@@ -6,7 +6,8 @@ use Mdanter\Ecc\EccFactory;
 use Mdanter\Ecc\Point;
 use Mdanter\Ecc\PrivateKey;
 use Mdanter\Ecc\PublicKey;
-use Mdanter\Ecc\Signature;
+use Mdanter\Ecc\Signature\Signature;
+use Mdanter\Ecc\Signature\Signer;
 
 /**
  * Raw Transaction Library
@@ -716,10 +717,12 @@ class RawTransaction
     public static function _check_sig($sig, $hash, $key)
     {
         $math = \Mdanter\Ecc\EccFactory::getAdapter();
-        $signature = self::decode_signature($sig);
-        $test_signature = new Signature($math->hexDec($signature['r']), $math->hexDec($signature['s']));
         $generator = \Mdanter\Ecc\EccFactory::getSecgCurves()->generator256k1();
         $curve = $generator->getCurve();
+
+        $hash = $math->hexDec($hash);
+        $signature = self::decode_signature($sig);
+        $test_signature = new Signature($math->hexDec($signature['r']), $math->hexDec($signature['s']));
 
         if (strlen($key) == '66') {
             $decompress = BitcoinLib::decompress_public_key($key);
@@ -728,14 +731,13 @@ class RawTransaction
             $x = $math->hexDec(substr($key, 2, 64));
             $y = $math->hexDec(substr($key, 66, 64));
 
-            $public_key_point = new Point($curve, $x, $y, $generator->getOrder(), $math);
+            $public_key_point = $curve->getPoint($x, $y);
         }
 
-        $public_key = new PublicKey($generator, $public_key_point, $math);
-        $hash = $math->hexDec($hash);
+        $signer = new Signer($math);
+        $public_key = new PublicKey($math, $generator, $public_key_point);
 
-        return $public_key->verifies($hash, $test_signature) == true;
-
+        return $signer->verify($public_key, $test_signature, $hash) == true;
     }
 
     /**
@@ -1102,24 +1104,20 @@ class RawTransaction
             if (isset($wallet[$tx_info['hash160']])) {
 
                 $key_info = $wallet[$tx_info['hash160']];
+                $message_hash_dec = $math->hexDec($message_hash[$vin]);
 
                 if ($key_info['type'] == 'scripthash') {
-
                     $signatures = self::extract_input_signatures_p2sh($input, $message_hash[$vin], $key_info);
-
                     $sign_count += count($signatures);
 
                     // Create Signature
                     foreach ($key_info['keys'] as $key) {
-
-                        $x = $math->hexDec(substr($key['uncompressed_key'], 2, 64));
-                        $y = $math->hexDec(substr($key['uncompressed_key'], 66, 64));
                         $key_dec = $math->hexDec($key['private_key']);
 
-                        $point = new \Mdanter\Ecc\Point($generator->getCurve(), $x, $y, $generator->getOrder(), $math);
-                        $_public_key = new PublicKey($generator, $point, $math);
-                        $_private_key = new PrivateKey($_public_key, $key_dec, $math);
-                        $sign = $_private_key->sign($math->hexDec($message_hash[$vin]), $math->hexDec((string)bin2hex(mcrypt_create_iv(32, \MCRYPT_DEV_URANDOM))));
+                        $signer = new Signer($math);
+                        $_private_key = $generator->getPrivateKeyFrom($key_dec);
+                        $sign = $signer->sign($_private_key, $message_hash_dec, $math->hexDec((string)bin2hex(mcrypt_create_iv(32, \MCRYPT_DEV_URANDOM))));
+
                         if ($sign !== false) {
                             $sign_count++;
                             $signatures[$key['public_key']] = self::encode_signature($sign);
@@ -1131,15 +1129,11 @@ class RawTransaction
                 }
 
                 if ($key_info['type'] == 'pubkeyhash') {
-                    $x = $math->hexDec(substr($key_info['uncompressed_key'], 2, 64));
-                    $y = $math->hexDec(substr($key_info['uncompressed_key'], 66, 64));
                     $key_dec = $math->hexDec($key_info['private_key']);
 
-                    // Create Signature
-                    $point = new \Mdanter\Ecc\Point($generator->getCurve(), $x, $y, $generator->getOrder(), $math);
-                    $_public_key = new PublicKey($generator, $point, $math);
-                    $_private_key = new PrivateKey($_public_key, $key_dec, $math);
-                    $sign = $_private_key->sign($math->hexDec($message_hash[$vin]), $math->hexDec((string)bin2hex(mcrypt_create_iv(32, \MCRYPT_DEV_URANDOM))));
+                    $signer = new Signer($math);
+                    $_private_key = $generator->getPrivateKeyFrom($key_dec);
+                    $sign = $signer->sign($_private_key, $message_hash_dec, $math->hexDec((string)bin2hex(mcrypt_create_iv(32, \MCRYPT_DEV_URANDOM))));
                     if ($sign !== false) {
                         $sign_count++;
                         $decode['vin'][$vin]['scriptSig']['hex'] = self::_apply_sig_pubkeyhash(self::encode_signature($sign), $key_info['public_key']);

--- a/tests/BIP32CoreTest.php
+++ b/tests/BIP32CoreTest.php
@@ -31,7 +31,7 @@ class BIP32CoreTest extends PHPUnit_Framework_TestCase {
 		$gmp_I_l = gmp_init($I_l, 16);
 		$gmp_private_key = gmp_init($private_key, 16);
 		$gmp_add = gmp_add($gmp_I_l, $gmp_private_key);
-
+		$gmp_add_res = gmp_strval($gmp_add, 10);
 
 
 		$this->assertEquals("105604983404708440304568772161069255144976878830542744455590282065741265022740", gmp_strval($gmp_I_l));
@@ -44,7 +44,7 @@ class BIP32CoreTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals("230500039711040884435309657843302549028061777533591645339274813439315011292506", gmp_strval(gmp_add(gmp_init($n), gmp_div_r($gmp_add, gmp_init($n)))));
 
 
-		$gmp_mod2 = $math->mod($gmp_add, $n);
+		$gmp_mod2 = $math->mod($gmp_add_res, $n);
 
 		$this->assertTrue(is_string($gmp_mod2));
 		$this->assertEquals("114707950473724689011738672834614641175224213254516740956669650297796849798169", $gmp_mod2);


### PR DESCRIPTION
Main changes are different signatures for PublicKey, and Point, have opted for $curve->getPoint($x, $y) which should avoid some of this in the future. 

Signature has moved namespace, and Signer is now used for signing/verifying. 