### PR TITLE
replace almost all `return false` statements with exceptions

### DIFF
--- a/src/BIP32.php
+++ b/src/BIP32.php
@@ -418,7 +418,7 @@ class BIP32
         $magic_byte_info = self::describe_magic_bytes($key['magic_bytes']);
         // Die if key type isn't supported by this library.
         if ($magic_byte_info == false) {
-            throw new \Exception("Unsupported magic byte");
+            throw new \InvalidArgumentException("Unsupported magic byte");
         }
 
         $key['type'] = $magic_byte_info['type'];

--- a/src/BIP32.php
+++ b/src/BIP32.php
@@ -140,11 +140,9 @@ class BIP32
         if ($previous['type'] == 'private') {
             $private_key = $previous['key'];
             $public_key = null;
-        } else if ($previous['type'] == 'public') {
+        } else {
             $private_key = null;
             $public_key = $previous['key'];
-        } else {
-            throw new \InvalidArgumentException("Unknown previous type in CKD");
         }
 
         $i = array_pop($address_definition);
@@ -158,10 +156,6 @@ class BIP32
         } else if ($is_prime == 0) {
             $public_key = $public_key ?: BitcoinLib::private_key_to_public_key($private_key, true);
             $data = $public_key . $i;
-        }
-
-        if (!isset($data)) {
-            throw new \Exception(); // I don't think this can happen
         }
 
         /*
@@ -555,12 +549,11 @@ class BIP32
     public static function key_to_address($extended_key)
     {
         $import = self::import($extended_key);
+
         if ($import['type'] == 'public') {
             $public = $import['key'];
-        } else if ($import['type'] == 'private') {
-            $public = BitcoinLib::private_key_to_public_key($import['key'], true);
         } else {
-            throw new \InvalidArgumentException("Unknown type");
+            $public = BitcoinLib::private_key_to_public_key($import['key'], true);
         }
 
         // Convert the public key to the address.

--- a/src/BIP32.php
+++ b/src/BIP32.php
@@ -86,11 +86,11 @@ class BIP32
 
         // seed min length is 128 bits (16 bytes)
         if (!$ignoreLengthCheck && strlen($seed) < 16) {
-            throw new \Exception("Seed should be at least 128 bits'");
+            throw new \InvalidArgumentException("Seed should be at least 128 bits'");
         }
         // seed max length is 512 bits (64 bytes)
         if (!$ignoreLengthCheck && strlen($seed) > 64) {
-            throw new \Exception("Seed should be at most 512 bits'");
+            throw new \InvalidArgumentException("Seed should be at most 512 bits'");
         }
 
         // Generate HMAC hash, and the key/chaincode.
@@ -150,7 +150,7 @@ class BIP32
         $is_prime = self::check_is_prime_hex($i);
         if ($is_prime == 1) {
             if ($previous['type'] == 'public') {
-                throw new \Exception("Can't derive private key from public key");
+                throw new \InvalidArgumentException("Can't derive private key from public key");
             }
             $data = '00' . $private_key . $i;
         } else if ($is_prime == 0) {
@@ -314,7 +314,7 @@ class BIP32
         if (strtolower(substr($string_def, 0, 1)) == 'm') {
             // the desired definition should start with the definition
             if (strpos($string_def, $def) !== 0) {
-                throw new \Exception("Path ({$string_def}) should match parent path ({$def}) when building key by absolute path");
+                throw new \InvalidArgumentException("Path ({$string_def}) should match parent path ({$def}) when building key by absolute path");
             }
 
             // unshift the definition to make the desired definition relative

--- a/src/BIP32.php
+++ b/src/BIP32.php
@@ -100,7 +100,7 @@ class BIP32
 
         // Error checking!
         if (self::check_valid_hmac_key($I_l) == false) {
-            return false;
+            throw new \InvalidArgumentException("Seed results in invalid key");
         }
 
         $data = array(
@@ -144,7 +144,7 @@ class BIP32
             $private_key = null;
             $public_key = $previous['key'];
         } else {
-            throw new \Exception("Unknown previous type in CKD");
+            throw new \InvalidArgumentException("Unknown previous type in CKD");
         }
 
         $i = array_pop($address_definition);
@@ -161,7 +161,7 @@ class BIP32
         }
 
         if (!isset($data)) {
-            return false;
+            throw new \Exception(); // I don't think this can happen
         }
 
         /*
@@ -216,11 +216,8 @@ class BIP32
             $new_x = str_pad(BitcoinLib::hex_encode($new_point->getX()), 64, '0', STR_PAD_LEFT);
             $new_y = str_pad(BitcoinLib::hex_encode($new_point->getY()), 64, '0', STR_PAD_LEFT);
             $key = BitcoinLib::compress_public_key('04' . $new_x . $new_y);
-
-        }
-
-        if (!isset($key)) {
-            return false;
+        } else {
+            throw new \InvalidArgumentException("Unknown previous type in CKD");
         }
 
         $data = array(
@@ -304,11 +301,11 @@ class BIP32
             $parent = $input;
             $def = "m";
         } else {
-            return false;
+            throw new \InvalidArgumentException("input should be string or [key, path]");
         }
 
         if (!preg_match("#^[mM/0-9']*$#", $string_def)) {
-            throw new \Exception("Path can only contain chars: [mM/0-9']");
+            throw new \InvalidArgumentException("Path can only contain chars: [mM/0-9']");
         }
 
         // if the desired path is public while the input is private
@@ -421,7 +418,7 @@ class BIP32
         $magic_byte_info = self::describe_magic_bytes($key['magic_bytes']);
         // Die if key type isn't supported by this library.
         if ($magic_byte_info == false) {
-            return false;
+            throw new \Exception("Unsupported magic byte");
         }
 
         $key['type'] = $magic_byte_info['type'];
@@ -444,12 +441,19 @@ class BIP32
         }
         $key['key'] = substr($hex, $key_start_position, $offset);
 
-        // Validate obtained key:
-        $validation = ($key['type'] == 'public')
-            ? BitcoinLib::validate_public_key($key['key'])
-            : self::check_valid_hmac_key($key['key']);
+        if (!in_array($key['type'], ['public', 'private'])) {
+            throw new \InvalidArgumentException("Invalid type");
+        }
 
-        return ($validation) ? $key : false;
+        // Validate obtained key
+        if ($key['type'] == 'public' && !BitcoinLib::validate_public_key($key['key'])) {
+            throw new \InvalidArgumentException("Invalid public key");
+        }
+        if ($key['type'] == 'private' && !self::check_valid_hmac_key($key['key'])) {
+            throw new \InvalidArgumentException("Invalid private key");
+        }
+
+        return $key;
     }
 
     /**
@@ -493,12 +497,12 @@ class BIP32
             $ext_private_key = $input;
             $generated = false;
         } else {
-            return false; // Exception? Not an array, or string?
+            throw new \InvalidArgumentException("input should be string or [key, path]");
         }
 
         $pubkey = self::import($ext_private_key);
         if ($pubkey['type'] !== 'private') {
-            return false; // Exception?
+            throw new \InvalidArgumentException("input is not a private key");
         }
 
         $pubkey['key'] = BitcoinLib::private_key_to_public_key($pubkey['key'], true);
@@ -531,7 +535,7 @@ class BIP32
             $ext_key = $input;
             $generated = false;
         } else {
-            return false;            // Exception?
+            throw new \InvalidArgumentException("input should be string or [key, path]");
         }
 
         $import = self::import($ext_key);
@@ -556,7 +560,7 @@ class BIP32
         } else if ($import['type'] == 'private') {
             $public = BitcoinLib::private_key_to_public_key($import['key'], true);
         } else {
-            return false;
+            throw new \InvalidArgumentException("Unknown type");
         }
 
         // Convert the public key to the address.
@@ -727,7 +731,7 @@ class BIP32
 
         // Check for invalid data
         if ($_equal_zero == 0 || $_GE_n == 1 || $_GE_n == 0) {
-            return false; // Exception?
+            return false;
         }
 
         return true;

--- a/src/BIP39/BIP39.php
+++ b/src/BIP39/BIP39.php
@@ -17,7 +17,7 @@ class BIP39
     public static function generateEntropy($size = 256)
     {
         if ($size % 32 !== 0) {
-            throw new \Exception("Entropy must be in a multiple of 32");
+            throw new \InvalidArgumentException("Entropy must be in a multiple of 32");
         }
 
         return bin2hex(mcrypt_create_iv($size / 8, \MCRYPT_DEV_URANDOM));
@@ -99,7 +99,7 @@ class BIP39
         $words = explode(" ", $mnemonic);
 
         if (count($words) % 3 !== 0) {
-            throw new \Exception("Invalid mnemonic");
+            throw new \InvalidArgumentException("Invalid mnemonic");
         }
 
         // wordList or default
@@ -130,7 +130,7 @@ class BIP39
 
         // validate
         if ($checksum !== self::entropyChecksum($entropyHex)) {
-            throw new \Exception("Checksum does not match!");
+            throw new \InvalidArgumentException("Checksum does not match!");
         }
 
         return $entropyHex;

--- a/src/BIP39/BIP39EnglishWordList.php
+++ b/src/BIP39/BIP39EnglishWordList.php
@@ -21,7 +21,7 @@ class BIP39EnglishWordList extends BIP39WordList
     public function getWord($idx)
     {
         if (!isset($this->words)) {
-            throw new \Exception(__CLASS__ . " does not contain a word for index [{$idx}]");
+            throw new \InvalidArgumentException(__CLASS__ . " does not contain a word for index [{$idx}]");
         }
 
         return $this->words[$idx];
@@ -35,7 +35,7 @@ class BIP39EnglishWordList extends BIP39WordList
         }
 
         if (!isset($this->wordsFlipped[$word])) {
-            throw new \Exception(__CLASS__ . " does not contain word  [{$word}]");
+            throw new \InvalidArgumentException(__CLASS__ . " does not contain word  [{$word}]");
         }
 
         return $this->wordsFlipped[$word];

--- a/src/BitcoinLib.php
+++ b/src/BitcoinLib.php
@@ -75,7 +75,7 @@ class BitcoinLib
         $magic_byte_defaults = explode('|', $magic_byte_defaults);
 
         if (count($magic_byte_defaults) != 2) {
-            throw new \Exception("magic_byte_defaults should magic_byte|magic_p2sh_byte");
+            throw new \InvalidArgumentException("magic_byte_defaults should magic_byte|magic_p2sh_byte");
         }
 
         self::$magic_byte = $magic_byte_defaults[0];
@@ -123,7 +123,7 @@ class BitcoinLib
             return $preset_magic_byte[0];
         }
 
-        throw new \Exception("Failed to determine magic_byte");
+        throw new \InvalidArgumentException("Failed to determine magic_byte");
     }
 
 
@@ -164,7 +164,7 @@ class BitcoinLib
             return $preset_magic_byte[1];
         }
 
-        throw new \Exception("Failed to determine magic_p2sh_byte");
+        throw new \InvalidArgumentException("Failed to determine magic_p2sh_byte");
     }
 
     /**
@@ -199,7 +199,7 @@ class BitcoinLib
             return $preset_magic_byte;
         }
 
-        throw new \Exception("Failed to determine magic_byte_pair");
+        throw new \InvalidArgumentException("Failed to determine magic_byte_pair");
     }
 
     /**

--- a/src/BitcoinLib.php
+++ b/src/BitcoinLib.php
@@ -604,8 +604,7 @@ class BitcoinLib
             return $public_key;
         }
 
-        // Not a valid public key
-        return false;
+        throw new \InvalidArgumentException("Invalid public key");
     }
 
     /**
@@ -663,7 +662,7 @@ class BitcoinLib
             $y0 = $theory->squareRootModP($y2, $curve->getPrime());
 
             if ($y0 == null) {
-                return false;
+                throw new \InvalidArgumentException("Invalid public key");
             }
 
             $y1 = $math->sub($curve->getPrime(), $y0);
@@ -675,13 +674,15 @@ class BitcoinLib
             $y_coordinate = str_pad($math->decHex($y), 64, '0', STR_PAD_LEFT);
             $point = new Point($curve, $x, $y, $generator->getOrder(), $math);
         } catch (\Exception $e) {
-            return false;
+            throw new \InvalidArgumentException("Invalid public key");
         }
 
-        return array('x' => $x_coordinate,
+        return array(
+            'x' => $x_coordinate,
             'y' => $y_coordinate,
             'point' => $point,
-            'public_key' => '04' . $x_coordinate . $y_coordinate);
+            'public_key' => '04' . $x_coordinate . $y_coordinate
+        );
     }
 
     /**

--- a/src/Jsonrpcclient.php
+++ b/src/Jsonrpcclient.php
@@ -111,7 +111,7 @@ class Jsonrpcclient
 
         // check the method/function
         if (!is_scalar($method)) {
-            throw new \Exception('Method name has no scalar value');
+            throw new \InvalidArgumentException('Method name has no scalar value');
         }
 
         // check the params are entered as an array
@@ -119,7 +119,7 @@ class Jsonrpcclient
             // no keys
             $params = array_values($params);
         } else {
-            throw new \Exception('Params must be given as array');
+            throw new \InvalidArgumentException('Params must be given as array');
         }
 
         // sets notification or request task

--- a/src/RawTransaction.php
+++ b/src/RawTransaction.php
@@ -147,7 +147,6 @@ class RawTransaction
      */
     public static function _encode_vint($decimal)
     {
-
         $hex = dechex($decimal);
         if ($decimal < 253) {
             $hint = self::_dec_to_bytes($decimal, 1);
@@ -162,7 +161,7 @@ class RawTransaction
             $hint = 'ff';
             $num_bytes = 8;
         } else {
-            return false;
+            throw new \InvalidArgumentException();
         }
 
         // If the number needs no extra bytes, just return the 1-byte number.
@@ -238,7 +237,7 @@ class RawTransaction
             if (strlen($raw_transaction) < 74
                 || !((hexdec(substr($raw_transaction, 72, 2)) + 74 + 8) < strlen($raw_transaction))
             ) {
-                return false;
+                throw new \InvalidArgumentException();
             }
 
             // Load the TxID (32bytes) and vout (4bytes)
@@ -454,7 +453,7 @@ class RawTransaction
             if (strlen($tx) < 8
                 || !(($math->hexDec(substr($tx, 8, 2)) + 8 + 2) < strlen($tx))
             ) {
-                return false;
+                throw new \InvalidArgumentException();
             }
 
             // Pop 8 bytes (flipped) from the $tx string, convert to decimal,
@@ -543,7 +542,7 @@ class RawTransaction
         if (((bool)preg_match('/^[0-9a-fA-F]{2,}$/i', $raw_transaction) !== true)
             || (strlen($raw_transaction)) % 2 !== 0
         ) {
-            return false;
+            throw new \InvalidArgumentException("Raw transaction is invalid hex");
         }
 
         $txid = hash('sha256', hash('sha256', pack("H*", trim($raw_transaction)), true));
@@ -552,22 +551,22 @@ class RawTransaction
         $info['txid'] = $txid;
         $info['version'] = $math->hexDec(self::_return_bytes($raw_transaction, 4, true), 16);
         if (!in_array($info['version'], array('1'))) {
-            return false;
+            throw new \InvalidArgumentException("Invalid transaction version");
         }
 
         $input_count = self::_get_vint($raw_transaction);
         if (!($input_count >= 0 && $input_count <= 4294967296)) {
-            return false;
+            throw new \InvalidArgumentException("Invalid input count");
         }
 
         $info['vin'] = self::_decode_inputs($raw_transaction, $input_count);
         if ($info['vin'] == false) {
-            return false;
+            throw new \InvalidArgumentException("No inputs in transaction");
         }
 
         $output_count = self::_get_vint($raw_transaction);
         if (!($output_count >= 0 && $output_count <= 4294967296)) {
-            return false;
+            throw new \InvalidArgumentException("Invalid output count");
         }
 
         $info['vout'] = self::_decode_outputs($raw_transaction, $output_count, $magic_byte, $magic_p2sh_byte);
@@ -655,18 +654,18 @@ class RawTransaction
 
         $inputs = (array)json_decode($json_inputs);
         if ($specific_input !== -1 && !is_numeric($specific_input)) {
-            return false;
+            throw new \InvalidArgumentException();
         }
 
         // Check that $raw_transaction and $json_inputs correspond to the right inputs
         for ($i = 0; $i < count($decode['vin']); $i++) {
             if (!isset($inputs[$i])) {
-                return false;
+                throw new \InvalidArgumentException();
             }
             if ($decode['vin'][$i]['txid'] !== $inputs[$i]->txid ||
                 $decode['vin'][$i]['vout'] !== $inputs[$i]->vout
             ) {
-                return false;
+                throw new \InvalidArgumentException();
             }
         }
 
@@ -761,7 +760,7 @@ class RawTransaction
 
         // Fail if the redeem_script has an uneven number of characters.
         if (strlen($redeem_script) % 2 !== 0) {
-            return false;
+            throw new \InvalidArgumentException();
         }
 
         // First step is to get m, the required number of signatures
@@ -800,13 +799,13 @@ class RawTransaction
                 // Finish the script - obtain n
                 $data['n'] = $math->sub($math->hexDec($next_op), $math->hexDec('50'));
                 if ($redeem_script !== 'ae') {
-                    return false;
+                    throw new \InvalidArgumentException();
                 }
 
                 $redeem_script = '';
             } else {
                 // Something weird, malformed redeemScript.
-                return false;
+                throw new \InvalidArgumentException();
             }
         }
         return self::decode_redeem_script($redeem_script, $data);
@@ -830,10 +829,11 @@ class RawTransaction
         $math = \Mdanter\Ecc\EccFactory::getAdapter();
 
         if (count($public_keys) == 0) {
-            return false;
+            throw new \InvalidArgumentException("No public keys provided");
         }
+
         if ($m == 0) {
-            return false;
+            throw new \InvalidArgumentException("M should be larger than 0");
         }
 
         $redeemScript = $math->decHex(0x50 + $m);
@@ -862,16 +862,14 @@ class RawTransaction
         $magic_p2sh_byte = BitcoinLib::magicP2SHByte($magic_p2sh_byte);
 
         if ($m == 0) {
-            return false;
+            throw new \InvalidArgumentException("M should be larger than 0");
         }
+
         if (count($public_keys) == 0) {
-            return false;
+            throw new \InvalidArgumentException("No public keys provided");
         }
 
         $redeem_script = self::create_redeem_script($m, $public_keys);
-        if ($redeem_script == false) {
-            return false;
-        }
 
         return array(
             'redeemScript' => $redeem_script,
@@ -934,9 +932,6 @@ class RawTransaction
         $magic_p2sh_byte = BitcoinLib::magicP2SHByte($magic_p2sh_byte);
 
         $decode = self::decode($raw_tx, $magic_byte, $magic_p2sh_byte);
-        if ($decode == false) {
-            return false;
-        }
 
         $json_arr = (array)json_decode($json_string);
 
@@ -1327,37 +1322,44 @@ class RawTransaction
      */
     public static function is_canonical_signature($signature)
     {
+        try {
+            return self::check_canonical_signature($signature);
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Check Canonical Signature
+     *
+     * Performs some checking on the given $signature to see if it
+     * it conforms to the standard.
+     *
+     * Throw exception when it's non canonical.
+     *
+     * @param   string $signature
+     * @return  bool
+     */
+    public static function check_canonical_signature($signature)
+    {
         $math = \Mdanter\Ecc\EccFactory::getAdapter();
 
-        $loud = false;
         $length = strlen($signature);
         if ($math->cmp($length, 18) < 0) {
-            if ($loud == true) {
-                echo "Non-canonical signature: too short\n";
-            }
-            return false;
+            throw new \Exception("Non-canonical signature: too short");
         }
 
         if ($math->cmp($length, 146) > 0) {
-            if ($loud == true) {
-                echo "Non-canonical signature: too long\n";
-            }
-            return false;
+            throw new \Exception("Non-canonical signature: too long");
         }
 
         // Non-canonical signature: too long
         if (substr($signature, 0, 2) !== '30') {
-            if ($loud == true) {
-                echo "Non-canonical signature: wrong type\n";
-            }
-            return false;
+            throw new \Exception("Non-canonical signature: wrong type");
         }
 
         if (substr($signature, 2, 2) !== $math->decHex((strlen($signature) / 2) - 3)) {
-            if ($loud == true) {
-                echo "Non-canonical signature: wrong length marker\n";
-            }
-            return false;
+            throw new \Exception("Non-canonical signature: wrong length marker");
         }
 
         $len_r_bytes = $math->hexDec(substr($signature, 6, 2));
@@ -1369,75 +1371,49 @@ class RawTransaction
         $s_first = substr($s, 0, 2);
 
         if ((5 + $len_r_bytes) >= $length) {
-            if ($loud == true) {
-                echo "Non-canonical signature: S length misplaced\n";
-            }
-            return false;
+            throw new \Exception("Non-canonical signature: S length misplaced");
         }
 
         if (($len_r_bytes + $len_s_bytes + 7) * 2 !== $length) {
-            if ($loud == true) {
-                echo "Non-canonical signature: R+S length mismatched\n";
-            }
-            return false;
+            throw new \Exception("Non-canonical signature: R+S length mismatched");
         }
 
         // This is the length of r: number of bytes, in hex.
 
         if (substr($signature, 4, 2) !== '02') {
-            if ($loud == true) {
-                echo "Non-canonical signature: R value type mismatch\n";
-            }
-            return false;
+            throw new \Exception("Non-canonical signature: R value type mismatch");
         }
 
         if ($len_r_bytes == 0) {
-            if ($loud == true) {
-                echo "Non-canonical signature: R length is zero\n";
-            }
-            return false;
+            throw new \Exception("Non-canonical signature: R length is zero");
         }
 
         $r_and = unpack("H*", (pack('H*', $r_first) & pack('H*', '80')));
         if ($r_and[1] == '80') {
-            if ($loud == true) {
-                echo "Non-canonical signature: R value negative\n";
-            }
-            return false;
+            throw new \Exception("Non-canonical signature: R value negative");
         }
 
         /*$r1_and = unpack( "H*", (pack('H*',substr($r, 0, 2)) & pack('H*', '80')));
         if($r_first == '00' && !($r1_and[1] == '80')) {
-            if($loud == true) echo "Non-canonical signature: R value excessively padded\n";
-            return false;
+            throw new \Exception("Non-canonical signature: R value excessively padded");
         }*/
 
         if (substr($signature, (4 + $len_r_bytes) * 2, 2) !== '02') {
-            if ($loud == true) {
-                echo "Non-canonical signature: S value type mismatch\n";
-            }
-            return false;
+            throw new \Exception("Non-canonical signature: S value type mismatch");
         }
 
         if ($len_s_bytes == 0) {
-            if ($loud == true) {
-                echo "Non-canonical signature: S length is zero\n";
-            }
-            return false;
+            throw new \Exception("Non-canonical signature: S length is zero");
         }
 
         $s_and = unpack("H*", (pack('H*', $s_first) & pack('H*', '80')));
         if ($s_and[1] == '80') {
-            if ($loud == true) {
-                echo "Non-canonical signature: S value negative\n";
-            }
-            return false;
+            throw new \Exception("Non-canonical signature: S value negative");
         }
 
         /*$s1_and = unpack( "H*", (pack('H*',substr($s, 0, 2)) & pack('H*', '80')));
         if($s_first == '00' && !($s1_and[1] == '80')) {
-            if($loud == true) echo "Non-canonical signature: S value excessively padded\n";
-            return false;
+            throw new \Exception("Non-canonical signature: S value excessively padded");
         }*/
 
         return true;

--- a/src/RawTransaction.php
+++ b/src/RawTransaction.php
@@ -161,7 +161,7 @@ class RawTransaction
             $hint = 'ff';
             $num_bytes = 8;
         } else {
-            throw new \InvalidArgumentException();
+            throw new \InvalidArgumentException("Invalid decimal");
         }
 
         // If the number needs no extra bytes, just return the 1-byte number.
@@ -237,7 +237,7 @@ class RawTransaction
             if (strlen($raw_transaction) < 74
                 || !((hexdec(substr($raw_transaction, 72, 2)) + 74 + 8) < strlen($raw_transaction))
             ) {
-                throw new \InvalidArgumentException();
+                throw new \InvalidArgumentException("Transaction is too short to contain all input data");
             }
 
             // Load the TxID (32bytes) and vout (4bytes)
@@ -453,7 +453,7 @@ class RawTransaction
             if (strlen($tx) < 8
                 || !(($math->hexDec(substr($tx, 8, 2)) + 8 + 2) < strlen($tx))
             ) {
-                throw new \InvalidArgumentException();
+                throw new \InvalidArgumentException("Transaction is too short to contain all output data");
             }
 
             // Pop 8 bytes (flipped) from the $tx string, convert to decimal,
@@ -654,18 +654,18 @@ class RawTransaction
 
         $inputs = (array)json_decode($json_inputs);
         if ($specific_input !== -1 && !is_numeric($specific_input)) {
-            throw new \InvalidArgumentException();
+            throw new \InvalidArgumentException("Specified input should be numeric");
         }
 
         // Check that $raw_transaction and $json_inputs correspond to the right inputs
         for ($i = 0; $i < count($decode['vin']); $i++) {
             if (!isset($inputs[$i])) {
-                throw new \InvalidArgumentException();
+                throw new \InvalidArgumentException("Raw transaction does not match expected inputs");
             }
             if ($decode['vin'][$i]['txid'] !== $inputs[$i]->txid ||
                 $decode['vin'][$i]['vout'] !== $inputs[$i]->vout
             ) {
-                throw new \InvalidArgumentException();
+                throw new \InvalidArgumentException("Raw transaction does not match expected inputs");
             }
         }
 
@@ -760,7 +760,7 @@ class RawTransaction
 
         // Fail if the redeem_script has an uneven number of characters.
         if (strlen($redeem_script) % 2 !== 0) {
-            throw new \InvalidArgumentException();
+            throw new \InvalidArgumentException("Redeem script is invalid hex");
         }
 
         // First step is to get m, the required number of signatures
@@ -799,13 +799,13 @@ class RawTransaction
                 // Finish the script - obtain n
                 $data['n'] = $math->sub($math->hexDec($next_op), $math->hexDec('50'));
                 if ($redeem_script !== 'ae') {
-                    throw new \InvalidArgumentException();
+                    throw new \InvalidArgumentException("Redeem script should be 'ae'");
                 }
 
                 $redeem_script = '';
             } else {
                 // Something weird, malformed redeemScript.
-                throw new \InvalidArgumentException();
+                throw new \InvalidArgumentException("Malformed redeem script");
             }
         }
         return self::decode_redeem_script($redeem_script, $data);

--- a/src/RawTransaction.php
+++ b/src/RawTransaction.php
@@ -1346,20 +1346,20 @@ class RawTransaction
 
         $length = strlen($signature);
         if ($math->cmp($length, 18) < 0) {
-            throw new \Exception("Non-canonical signature: too short");
+            throw new \InvalidArgumentException("Non-canonical signature: too short");
         }
 
         if ($math->cmp($length, 146) > 0) {
-            throw new \Exception("Non-canonical signature: too long");
+            throw new \InvalidArgumentException("Non-canonical signature: too long");
         }
 
         // Non-canonical signature: too long
         if (substr($signature, 0, 2) !== '30') {
-            throw new \Exception("Non-canonical signature: wrong type");
+            throw new \InvalidArgumentException("Non-canonical signature: wrong type");
         }
 
         if (substr($signature, 2, 2) !== $math->decHex((strlen($signature) / 2) - 3)) {
-            throw new \Exception("Non-canonical signature: wrong length marker");
+            throw new \InvalidArgumentException("Non-canonical signature: wrong length marker");
         }
 
         $len_r_bytes = $math->hexDec(substr($signature, 6, 2));
@@ -1371,49 +1371,49 @@ class RawTransaction
         $s_first = substr($s, 0, 2);
 
         if ((5 + $len_r_bytes) >= $length) {
-            throw new \Exception("Non-canonical signature: S length misplaced");
+            throw new \InvalidArgumentException("Non-canonical signature: S length misplaced");
         }
 
         if (($len_r_bytes + $len_s_bytes + 7) * 2 !== $length) {
-            throw new \Exception("Non-canonical signature: R+S length mismatched");
+            throw new \InvalidArgumentException("Non-canonical signature: R+S length mismatched");
         }
 
         // This is the length of r: number of bytes, in hex.
 
         if (substr($signature, 4, 2) !== '02') {
-            throw new \Exception("Non-canonical signature: R value type mismatch");
+            throw new \InvalidArgumentException("Non-canonical signature: R value type mismatch");
         }
 
         if ($len_r_bytes == 0) {
-            throw new \Exception("Non-canonical signature: R length is zero");
+            throw new \InvalidArgumentException("Non-canonical signature: R length is zero");
         }
 
         $r_and = unpack("H*", (pack('H*', $r_first) & pack('H*', '80')));
         if ($r_and[1] == '80') {
-            throw new \Exception("Non-canonical signature: R value negative");
+            throw new \InvalidArgumentException("Non-canonical signature: R value negative");
         }
 
         /*$r1_and = unpack( "H*", (pack('H*',substr($r, 0, 2)) & pack('H*', '80')));
         if($r_first == '00' && !($r1_and[1] == '80')) {
-            throw new \Exception("Non-canonical signature: R value excessively padded");
+            throw new \InvalidArgumentException("Non-canonical signature: R value excessively padded");
         }*/
 
         if (substr($signature, (4 + $len_r_bytes) * 2, 2) !== '02') {
-            throw new \Exception("Non-canonical signature: S value type mismatch");
+            throw new \InvalidArgumentException("Non-canonical signature: S value type mismatch");
         }
 
         if ($len_s_bytes == 0) {
-            throw new \Exception("Non-canonical signature: S length is zero");
+            throw new \InvalidArgumentException("Non-canonical signature: S length is zero");
         }
 
         $s_and = unpack("H*", (pack('H*', $s_first) & pack('H*', '80')));
         if ($s_and[1] == '80') {
-            throw new \Exception("Non-canonical signature: S value negative");
+            throw new \InvalidArgumentException("Non-canonical signature: S value negative");
         }
 
         /*$s1_and = unpack( "H*", (pack('H*',substr($s, 0, 2)) & pack('H*', '80')));
         if($s_first == '00' && !($s1_and[1] == '80')) {
-            throw new \Exception("Non-canonical signature: S value excessively padded");
+            throw new \InvalidArgumentException("Non-canonical signature: S value excessively padded");
         }*/
 
         return true;


### PR DESCRIPTION
most `return false` statements were actually just argument checks so they really do make a lot of sense to be replaced with exceptions.

I left the methods that are `is_smt_smt_ok` or `validate_smt_smt` to return true/false since that's the purpose of the method.

I added `is_canonical_signature` which returns true/false and renamed the old one to `check_canonical_signature` which actually throws with a specific message.  
Because `extract_input_signatures_p2sh` is the only place it's being used right now and it's used to check if something is a sig, not really to validate it.

Also left 2 in RawTransaction::create because the float PR is fixing those and otherwise merge conflicts.


@btcdrak, @afk11 there's 2 places I wasn't sure what to do:

In `BitcoinLib::private_key_to_public_key` (https://github.com/Bit-Wasp/bitcoin-lib-php/blob/master/src/BitcoinLib.php#L438) an exception from `GeneratorPoint::mul` is caught and returns false, idk if this should be replaced (or just let the exception be thrown).

In `BitcoinLib::recoverPubKey` (https://github.com/Bit-Wasp/bitcoin-lib-php/blob/master/src/BitcoinLib.php#L914) we return false if it fails, I think that's correct too ..?