### PR TITLE
better _decode_outputs

### DIFF
--- a/src/RawTransaction.php
+++ b/src/RawTransaction.php
@@ -71,6 +71,10 @@ class RawTransaction
      */
     public static function _return_bytes(&$string, $byte_count, $reverse = false)
     {
+        if (strlen($string) < $byte_count * 2) {
+            throw new \InvalidArgumentException("Could not read enough bytes");
+        }
+
         $requested_bytes = substr($string, 0, $byte_count * 2);
 
         // Overwrite $string, starting $byte_count bytes from the start.
@@ -257,14 +261,6 @@ class RawTransaction
         // Loop until $input count is reached, sequentially removing the
         // leading data from $raw_transaction reference.
         for ($i = 0; $i < $input_count; $i++) {
-            // Check that the variable has at least 36 bytes, and that the
-            // required length for this input is less than the length of the raw_transaction string.
-            if (strlen($raw_transaction) < 74
-                || !((hexdec(substr($raw_transaction, 72, 2)) + 74 + 8) < strlen($raw_transaction))
-            ) {
-                throw new \InvalidArgumentException("Transaction is too short to contain all input data");
-            }
-
             // Load the TxID (32bytes) and vout (4bytes)
             $txid = self::_return_bytes($raw_transaction, 32, true);
             $vout = self::_return_bytes($raw_transaction, 4, true);
@@ -475,13 +471,6 @@ class RawTransaction
 
         $outputs = array();
         for ($i = 0; $i < $output_count; $i++) {
-            // Check the $tx has sufficient length to cover this input.
-            if (strlen($tx) < 8
-                || !(($math->hexDec(substr($tx, 8, 2)) + 8 + 2) < strlen($tx))
-            ) {
-                throw new \InvalidArgumentException("Transaction is too short to contain all output data");
-            }
-
             // Pop 8 bytes (flipped) from the $tx string, convert to decimal,
             // and then convert to Satoshis.
             $satoshis = $math->hexDec(self::_return_bytes($tx, 8, true), 16, 10);

--- a/tests/RawTransactionTest.php
+++ b/tests/RawTransactionTest.php
@@ -449,6 +449,33 @@ class RawTransactionTest extends PHPUnit_Framework_TestCase
         }
     }
 
-}
+    public function testDecodeTx() {
+        $hex = "0100000001552eed137888e6a6c2c69ded505d9e573c3d78ab0f478ecbdaf74b99b40f350d010000006b483045022100d958e320b5bbc700e7862b7832fc86d18f50be7a272399c38b35a6aecd471d68022014a02f0387a0971c4e06cac086d662615a3e07a0323e1f138d96c54c7f6aaead012102af6034f808ee5989a7ea0304cc7d464edb22a86d362739aeb4e52e759436b7f5ffffffff0240480801000000001976a91415df9c5643a3ef61ee05a92a7703f47a4ffbbcdb88ac8b0361695e0000001976a91490967f997eda3a1c0bd4358b3cd19824e46538b688ac00000000";
 
-;
+        $tx = RawTransaction::decode($hex);
+
+        $this->assertEquals("fd07ba46ae08d639577b12d3fe91f44de37152768a6db5e9685828054fed5feb", $tx['txid']);
+        $this->assertEquals("1", $tx['version']);
+        $this->assertEquals(1, count($tx['vin']));
+        $this->assertEquals(2, count($tx['vout']));
+        $this->assertEquals("0d350fb4994bf7dacb8e470fab783d3c579e5d50ed9dc6c2a6e6887813ed2e55", $tx['vin'][0]['txid']);
+        $this->assertEquals(1, $tx['vin'][0]['vout']);
+        $this->assertEquals("17320000", $tx['vout'][0]['value']);
+        $this->assertEquals("76a91415df9c5643a3ef61ee05a92a7703f47a4ffbbcdb88ac", $tx['vout'][0]['scriptPubKey']['hex']);
+        $this->assertEquals("405494891403", $tx['vout'][1]['value']);
+        $this->assertEquals("76a91490967f997eda3a1c0bd4358b3cd19824e46538b688ac", $tx['vout'][1]['scriptPubKey']['hex']);
+    }
+
+    /**
+     * took a valid TX hex and removed 1 byte from a output script
+     */
+    public function testDecodeBadTx() {
+        $e = null;
+        try {
+            $hex = "0100000001552eed137888e6a6c2c69ded505d9e573c3d78ab0f478ecbdaf74b99b40f350d010000006b483045022100d958e320b5bbc700e7862b7832fc86d18f50be7a272399c38b35a6aecd471d68022014a02f0387a0971c4e06cac086d662615a3e07a0323e1f138d96c54c7f6aaead012102af6034f808ee5989a7ea0304cc7d464edb22a86d362739aeb4e52e759436b7f5ffffffff0240480801000000001976a91415df9c5643a3ef61ee05a92a7703f47a4ffbbcdb88ac8b0361695e0000001976a91490967f997eda3a1c0bd4358b3cd19824e46538b6ac00000000";
+            $tx = RawTransaction::decode($hex);
+        } catch (\Exception $e) {}
+        $this->assertTrue(!!$e);
+    }
+
+}


### PR DESCRIPTION
 - throw exception when trying to read bytes that aren't there.
 - no longer need the 'manual' strlen checks.

Fixes https://github.com/Bit-Wasp/bitcoin-lib-php/issues/67