### PR TITLE
prepare for segwit merge

### DIFF
--- a/src/RawTransaction.php
+++ b/src/RawTransaction.php
@@ -30,7 +30,7 @@ class RawTransaction
      *
      * @var bool
      */
-    const ALLOW_HIGH_S = true;
+    const ALLOW_HIGH_S = false;
 
     /**
      * Some of the defined OP CODES available in Bitcoins script.
@@ -599,7 +599,7 @@ class RawTransaction
         $info = array();
         $info['txid'] = $txid;
         $info['version'] = $math->hexDec(self::_return_bytes($raw_transaction, 4, true));
-        if (!in_array($info['version'], array('0', '1'))) {
+        if (!in_array($info['version'], array('0', '1', '2'))) {
             throw new \InvalidArgumentException("Invalid transaction version");
         }
 


### PR DESCRIPTION
allowing high S value prevents bitwasp from working.
also, version 2 of transaction is already in action  in testnet:
https://sandbox.smartbit.com.au/tx/5029542bfc2d8feb4ca9ee33e78ae52f6fabe302ee0755771eb19dcd72110ff4
