### PR TITLE
add new deriveAddressFromSignature function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "bitwasp/bitcoin-lib",
+    "name": "tokenly/bitcoin-lib",
     "description": "Implementation of raw transactions in bitcoin, HD wallets, Electrum wallets, and other fun stuff.",
     "keywords": ["bitcoin", "php", "bip32", "electrum", "ecc", "transactions", "HD wallet","btc", "cryptocurrency"],
     "license": "Unlicense",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "tokenly/bitcoin-lib",
+    "name": "bitwasp/bitcoin-lib",
     "description": "Implementation of raw transactions in bitcoin, HD wallets, Electrum wallets, and other fun stuff.",
     "keywords": ["bitcoin", "php", "bip32", "electrum", "ecc", "transactions", "HD wallet","btc", "cryptocurrency"],
     "license": "Unlicense",

--- a/src/BIP32.php
+++ b/src/BIP32.php
@@ -199,7 +199,6 @@ class BIP32
             $private_key_dec = $math->hexDec($private_key);
             $key_dec = $math->mod($math->add($Il_dec, $private_key_dec), $n);
             $key = str_pad(BitcoinLib::hex_encode($key_dec), 64, '0', STR_PAD_LEFT);
-
         } else if ($previous['type'] == 'public') {
             // newPoint + parentPubkeyPoint
             $decompressed = BitcoinLib::decompress_public_key($public_key); // Can return false. Throw exception?

--- a/src/BitcoinLib.php
+++ b/src/BitcoinLib.php
@@ -1091,15 +1091,14 @@ class BitcoinLib
     
     
     /**
-     * derive the public address of the key used to verify a signed message
-     * functionally identical to verifyMessage function but different return value
+     * derive the public btc address of the key used to verify a signed message
      *
      * @param $signature
      * @param $message
      * @return string
      * @throws \Exception
      */
-    public static function deriveAddressFromMessage($signature, $message)
+    public static function deriveAddressFromSignature($signature, $message)
     {
         $math = EccFactory::getAdapter();
         $generator = EccFactory::getSecgCurves($math)->generator256k1();
@@ -1155,9 +1154,9 @@ class BitcoinLib
                 (($math->mod($point->getY(), 2) == 0) ? "\x02" : "\x03") .
                 str_pad(hex2bin(self::padHex($math->decHex($point->getX()))), 32, "\x00", STR_PAD_LEFT);
         }
-
-        $derivedAddress = hex2bin(self::magicByte()) . hash('ripemd160', hash('sha256', $pubBinStr, true), true);
-
+        
+        $derivedAddress = self::public_key_to_address(bin2hex($pubBinStr));
+        
         return $derivedAddress;
     }    
 }

--- a/src/BitcoinLib.php
+++ b/src/BitcoinLib.php
@@ -1105,11 +1105,6 @@ class BitcoinLib
         $generator = EccFactory::getSecgCurves($math)->generator256k1();
 
         // extract parameters
-        $address = substr(hex2bin(self::base58_decode($address)), 0, -4);
-        if (strlen($address) != 21 || $address[0] != hex2bin(self::magicByte())) {
-            throw new \InvalidArgumentException('invalid Bitcoin address');
-        }
-
         $signature = base64_decode($signature, true);
         if ($signature === false) {
             throw new \InvalidArgumentException('invalid base64 signature');

--- a/src/BitcoinLib.php
+++ b/src/BitcoinLib.php
@@ -660,7 +660,6 @@ class BitcoinLib
 
             $y_coordinate = str_pad($math->decHex($y), 64, '0', STR_PAD_LEFT);
             $point = $curve->getPoint($x, $y);
-
         } catch (\Exception $e) {
             throw new \InvalidArgumentException("Invalid public key");
         }
@@ -706,7 +705,6 @@ class BitcoinLib
             } catch (\Exception $e) {
                 return false;
             }
-
         }
 
         return false;
@@ -1049,7 +1047,7 @@ class BitcoinLib
     public static function deriveAddressFromSignature($signature, $message, $as_bin = false)
     {
         $pubkey = self::derivePubKeyFromSignature($signature, $message, $as_bin);
-        if($as_bin){
+        if ($as_bin) {
             return hex2bin(self::magicByte()) . hash('ripemd160', hash('sha256', $pubkey, true), true);
         }
         return self::public_key_to_address($pubkey);
@@ -1064,7 +1062,7 @@ class BitcoinLib
      * @param false $as_bin
      * @return string
      * @throws \Exception
-     */    
+     */
     public static function derivePubKeyFromSignature($signature, $message, $as_bin = false)
     {
         $math = EccFactory::getAdapter();
@@ -1122,7 +1120,7 @@ class BitcoinLib
                 str_pad(hex2bin(self::padHex($math->decHex($point->getX()))), 32, "\x00", STR_PAD_LEFT);
         }
         
-        if(!$as_bin){
+        if (!$as_bin) {
             return bin2hex($pubBinStr);
         }
         

--- a/src/Jsonrpcclient.php
+++ b/src/Jsonrpcclient.php
@@ -161,7 +161,6 @@ class Jsonrpcclient
             }
 
             return $response['result'];
-
         } else {
             return true;
         }

--- a/src/RawTransaction.php
+++ b/src/RawTransaction.php
@@ -369,11 +369,9 @@ class RawTransaction
                 } else {
                     $data[] = self::$op_code[$byteHex];
                 }
-
             } elseif ($byteInt >= 0x01 && $byteInt <= 0x4b) {
                 // This checks if the OPCODE falls in the PUSHDATA range
                 $data[] = self::_return_bytes($script, $byteInt);
-
             } elseif ($byteInt >= 0x51 && $byteInt <= 0x60) {
                 // This checks if the CODE falls in the OP_X range
                 $data[] = $matchBitcoinCore ? ($byteInt - 0x50) : 'OP_' . ($byteInt - 0x50);
@@ -528,7 +526,6 @@ class RawTransaction
                 'value' => $satoshis,
                 'vout' => $i,
                 'scriptPubKey' => $scriptPubKey);
-
         }
         return $outputs;
     }
@@ -723,7 +720,6 @@ class RawTransaction
                 // and calculate a double sha256 hash for this input.
                 $hash[] = hash('sha256', hash('sha256', pack("H*", self::encode($copy) . $sighashcode), true));
             }
-
         } else {
             // Return a message hash for the specified output.
             $copy = $decode;
@@ -825,7 +821,6 @@ class RawTransaction
             $data['m'] = $math->sub($math->hexDec(substr($redeem_script, 0, 2)), $math->hexDec('50'));
             $data['keys'] = array();
             $redeem_script = substr($redeem_script, 2);
-
         } elseif (count($data['keys']) == 0 && !isset($data['next_key_charlen'])) {
             // Next is to find out the length of the following public key.
             $hex = substr($redeem_script, 0, 2);
@@ -988,7 +983,6 @@ class RawTransaction
                 $public_key = $scripts[1];
                 $o = self::_check_sig($signature, $message_hash[$i], $public_key, $allowHighS);
                 $outcome = $outcome && $o;
-
             } elseif ($type_info['type'] == 'scripthash') {
                 // Pay-to-script-hash. Check OP_FALSE <sig> ... <redeemScript>
                 $redeem_script_found = false;
@@ -1572,7 +1566,6 @@ class RawTransaction
                     'address' => BitcoinLib::hash160_to_address($scripthash, $magic_p2sh_byte),
                     'public_keys' => $decode['keys'],
                     'keys' => $keys);
-
             }
         }
     }

--- a/tests/SignVerifyMessageTest.php
+++ b/tests/SignVerifyMessageTest.php
@@ -132,4 +132,19 @@ class SignVerifyMessageTest extends PHPUnit_Framework_TestCase
             $this->assertTrue($rpc->verifymessage($row['address'], $signature, $row['address']));
         }
     }
+    
+    
+    public function testDeriveAddressFromSignature()
+    {
+        $k = "40830342147156906673307227534819286677883886097095155210766904187107130350230"; // fixed K value for testing
+
+        $WIF = "KxuKf1nB3nZ5eYVFVuCgvH5EFM8iUSWqmqJ9bAQukekYgPbju4FL";
+        $privKey = BitcoinLib::WIF_to_private_key($WIF);
+        $test_message = 'this is a test';
+        $true_address = '12XJYLMM9ZoDZjmBZ1SeFANhgCVjwNYgVm';
+        $test_sig = BitcoinLib::signMessage($test_message, $privKey, $k);
+        $derived = BitcoinLib::deriveAddressFromSignature($test_sig, $test_message);
+        
+        $this->assertEquals($true_address, $derived);
+    }    
 }


### PR DESCRIPTION
I added in this method which returns the public BTC address used to sign a particular message, using only signature+message as parameters. Using this for a "sign in with verified bitcoin address" feature on a project