### PR TITLE
BUGFIX: validate_signed_transaction reported an input as fully signed…

### DIFF
--- a/src/BitcoinLib.php
+++ b/src/BitcoinLib.php
@@ -247,7 +247,6 @@ class BitcoinLib
             $return = "0" . $return;
         }
         return $return;
-
     }
 
     /**
@@ -631,7 +630,6 @@ class BitcoinLib
 
         $parity = $math->mod($y, 2);
         return (($parity == 0) ? '02' : '03') . $x_hex;
-
     }
 
     /**

--- a/src/RawTransaction.php
+++ b/src/RawTransaction.php
@@ -816,7 +816,7 @@ class RawTransaction
 
         // First step is to get m, the required number of signatures
         if (!isset($data['m']) || count($data) == 0) {
-            $data['m'] = $math->sub($math->hexDec(substr($redeem_script, 0, 2)), $math->hexDec('50'));
+            $data['m'] = (int) $math->sub($math->hexDec(substr($redeem_script, 0, 2)), $math->hexDec('50'));
             $data['keys'] = array();
             $redeem_script = substr($redeem_script, 2);
         } elseif (count($data['keys']) == 0 && !isset($data['next_key_charlen'])) {
@@ -846,7 +846,7 @@ class RawTransaction
                 && in_array($math->cmp($math->hexDec($next_op), $math->hexDec('60')), array(-1, 0))
             ) {
                 // Finish the script - obtain n
-                $data['n'] = $math->sub($math->hexDec($next_op), $math->hexDec('50'));
+                $data['n'] = (int) $math->sub($math->hexDec($next_op), $math->hexDec('50'));
                 if ($redeem_script !== 'ae') {
                     throw new \InvalidArgumentException("Redeem script should be 'ae'");
                 }
@@ -1015,7 +1015,7 @@ class RawTransaction
                     }
                 }
 
-                $outcome = $outcome && ($redeem_script_found && $pubkey_found == $redeemScript['m']);
+                $outcome = $outcome && ($redeem_script_found && $pubkey_found === $redeemScript['m']);
             }
         }
 

--- a/src/RawTransaction.php
+++ b/src/RawTransaction.php
@@ -1009,6 +1009,9 @@ class RawTransaction
                         foreach ($redeemScript['keys'] as $public_key) {
                             if (self::_check_sig($signature, $message_hash[$i], $public_key) == true) {
                                 $pubkey_found++;
+                                if ($pubkey_found == $redeemScript['m']) {
+                                    break 2;
+                                }
                             }
                         }
                     }

--- a/src/RawTransaction.php
+++ b/src/RawTransaction.php
@@ -817,6 +817,9 @@ class RawTransaction
         // First step is to get m, the required number of signatures
         if (!isset($data['m']) || count($data) == 0) {
             $data['m'] = (int) $math->sub($math->hexDec(substr($redeem_script, 0, 2)), $math->hexDec('50'));
+            if ($data['m'] < 0 || $data['m'] > 20) {
+                throw new \RuntimeException("Invalid redeem script - m must be >0 and <=20");
+            }
             $data['keys'] = array();
             $redeem_script = substr($redeem_script, 2);
         } elseif (count($data['keys']) == 0 && !isset($data['next_key_charlen'])) {
@@ -847,6 +850,9 @@ class RawTransaction
             ) {
                 // Finish the script - obtain n
                 $data['n'] = (int) $math->sub($math->hexDec($next_op), $math->hexDec('50'));
+                if ($data['n'] < 0 || $data['n'] > 20) {
+                    throw new \RuntimeException("Invalid redeem script - n must be >0 and <=20");
+                }
                 if ($redeem_script !== 'ae') {
                     throw new \InvalidArgumentException("Redeem script should be 'ae'");
                 }

--- a/src/RawTransaction.php
+++ b/src/RawTransaction.php
@@ -147,7 +147,6 @@ class RawTransaction
         // Num_bytes is 0: Just return the decimal
         // Otherwise, return $num_bytes bytes (order flipped) and converted to decimal
         return ($num_bytes == 0) ? $decimal : hexdec(self::_return_bytes($string, $num_bytes, true));
-
     }
 
     /**
@@ -647,7 +646,6 @@ class RawTransaction
         $encoded_locktime = self::_dec_to_bytes($raw_transaction_array['locktime'], 4, true);
 
         return $encoded_version . $encoded_inputs . $encoded_outputs . $encoded_locktime;
-
     }
 
     /**
@@ -1130,7 +1128,6 @@ class RawTransaction
         $tx_array['locktime'] = 0;
 
         return self::encode($tx_array);
-
     }
 
     /**
@@ -1484,7 +1481,6 @@ class RawTransaction
         }
 
         return true;
-
     }
 
     /**

--- a/tests/RawTransactionTest.php
+++ b/tests/RawTransactionTest.php
@@ -79,6 +79,7 @@ class RawTransactionTest extends PHPUnit_Framework_TestCase
         RawTransaction::private_keys_to_wallet($wallet, array("cV2BRcdtWoZMSovYCpoY9gyvjiVK5xufpAwdAFk1jdonhGZq1cCm"));
         RawTransaction::redeem_scripts_to_wallet($wallet, array($redeem_script));
         $sign = RawTransaction::sign($wallet, $raw_transaction, json_encode($inputs));
+        $this->assertFalse(RawTransaction::validate_signed_transaction($sign['hex'], json_encode($inputs)));
         $this->assertEquals(2, $sign['req_sigs']);
         $this->assertEquals(1, $sign['sign_count']);
         $this->assertEquals('false', $sign['complete']);
@@ -93,17 +94,7 @@ class RawTransactionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(2, $sign['req_sigs']);
         $this->assertEquals(2, $sign['sign_count']);
         $this->assertEquals('true', $sign['complete']);
-
-        /*
-         * sign with third key
-         */
-        $wallet = array();
-        RawTransaction::private_keys_to_wallet($wallet, array("cNn72iUvQhuzZCWg3TC31fvyNDYttL8emHgMcFJzhF4xnFo8LYCk"));
-        RawTransaction::redeem_scripts_to_wallet($wallet, array($redeem_script));
-        $sign = RawTransaction::sign($wallet, $sign['hex'], json_encode($inputs));
-        $this->assertEquals(2, $sign['req_sigs']);
-        $this->assertEquals(3, $sign['sign_count']);
-        $this->assertEquals('true', $sign['complete']);
+        $this->assertTrue(RawTransaction::validate_signed_transaction($sign['hex'], json_encode($inputs)));
 
         BitcoinLib::setMagicByteDefaults('bitcoin');
     }
@@ -394,7 +385,6 @@ class RawTransactionTest extends PHPUnit_Framework_TestCase
 
 
         foreach ($data as $test) {
-
             $this->assertTrue(RawTransaction::validate_signed_transaction($test['tx'], json_encode($test['inputs']), '00'));
         }
     }


### PR DESCRIPTION
… if first multisig signature was correct

Solution:
pubkey_found(bool) is now a pubkey_found(int=0) and is incremented with each solution. A break is only done if all public keys have been found.

We only bother checking this if the transaction is already fully signed (nSigs = requiredSigs)

If $outcome is still true, check that $pubkey_found === $redeemScript['m'] (decode_redeem_script's m and n parameters are now cast to integers)