### PR TITLE
Replace deprecated function

### DIFF
--- a/src/BIP39/BIP39.php
+++ b/src/BIP39/BIP39.php
@@ -20,7 +20,7 @@ class BIP39
             throw new \InvalidArgumentException("Entropy must be in a multiple of 32");
         }
 
-        return bin2hex(mcrypt_create_iv($size / 8, \MCRYPT_DEV_URANDOM));
+        return bin2hex(random_bytes($size / 8));
     }
 
     /**


### PR DESCRIPTION
According to https://secure.php.net/mcrypt_create_iv. An appropriate alternative is the PHP function random_bytes()